### PR TITLE
2. Mobil labor javítások

### DIFF
--- a/docs/laborok/02-android-ui/index.md
+++ b/docs/laborok/02-android-ui/index.md
@@ -1098,7 +1098,7 @@ fun PreviewPassScreen() {
 Mivel a `PassScreen`-nek szüksége van a jegy típusára, valamint az érvényességi idejére, ezt egy paraméterként kapja meg, majd ezt egy függvényen belül feldolgozzuk, és az alábbiak szerint használjuk fel.
 
 - `yyyy. mm. dd.;yyyy. mm. dd.;category` a felépítése a kapott Stringnek
-- Ezt feldaraboljuk a `;` mentén, majd a dátumot string interpoláció segítségével átadjuk a `Text` Composable értékének, a price-t pedig egy másik `Text` Composable-nak
+- Ezt feldaraboljuk a `;` mentén, majd a dátumot string interpoláció segítségével átadjuk a `Text` Composable értékének, a category-t pedig egy másik `Text` Composable-nak
 
 !!!info ""
 	 Látható, hogy a Java-val ellentétben a Kotlin támogatja a [string interpolációt](https://kotlinlang.org/docs/reference/basic-types.html#string-templates).

--- a/docs/laborok/02-android-ui/index.md
+++ b/docs/laborok/02-android-ui/index.md
@@ -282,7 +282,7 @@ Most már elkészíthetjük a login képernyőt. A felhasználótól egy e-mail 
 <img src="./assets/login.png" width="320">
 </p>
 
-Ehhez először hozzunk létre egy új *Packaget* a projekt mappába `navigation` néven, majd ebbe hozzunk létre két *Kotlin Filet* (a *Package*-ünkön jobb klikk -> New -> Kotlin Class/File) `NavGraph` illetve `Screen` néven. Ez utóbbira csak azért lesz szükség, hogy a későbbiekben szebben tudjuk megoldani a navigációt a képernyők között. Ezt az [Extra feladat - Screen File](#ismerteto-feladat-screen-file) résznél fogjuk részletezve leírni az érdeklődők kedvéért.
+Ehhez először hozzunk létre egy új *Packaget* a projekt mappába `navigation` néven, majd ebbe hozzunk létre két *Kotlin Filet* (a *Package*-ünkön jobb klikk -> New -> Kotlin Class/File) `NavGraph` illetve `Screen` néven. Ez utóbbira csak azért lesz szükség, hogy a későbbiekben szebben tudjuk megoldani a navigációt a képernyők között. Ezt az [Extra feladat - Különálló Screen File](#extra-feladat-kulonallo-screen-file) résznél fogjuk részletezve leírni az érdeklődők kedvéért.
 
 Nyissuk meg a `NavGraph` fájlt, és írjuk bele a következő kódot, majd nézzük át és értelmezzük a laborvezető segítségével a kódot.
 
@@ -1363,7 +1363,7 @@ Az újonnan hozzáadott `composable` elem a `NavGraph`-ban a következő képpen
 Majd ezután a `Manifest` fájl személyre szabható, hogy milyen témát jelenítsen meg.
 
 
-### Extra feladat - különálló Screen File
+### Extra feladat - Különálló Screen File
 
 Nagy projektekben, ahol több képernyő található, egy idő után kényelmetlen megoldás lehet a *screenek* közötti *stringekkel* történő navigáció. Ezért általános megoldás, hogy a képernyőket, és a hozzájuk kapcsolódó navigációs utakat egy különálló `Screen` osztályba gyűjtjük, majd a navigációs gráfban csak a belőlük képzett objektumokat használjuk. A korábban létrehozott `Screen` fájl az alábbi kódot fogja tartalmazni:
 

--- a/docs/laborok/02-android-ui/index.md
+++ b/docs/laborok/02-android-ui/index.md
@@ -221,7 +221,7 @@ Az új stílusunk a `Theme.PublicTransport.Starting` nevet viseli, és a `Theme.
 !!!note
 	A Splash Screen API ennél jóval többet tud, akár animálhatjuk is a megjelenített képet, azonban ez sajnos túlmutat a labor keretein.
 
-Most már, hogy bekonfiguráltuk a *splash* képernyőnket, már csak be kell állítanunk a használatát. Ehhez először az imént létrehozott stílust kell alkalmaznunk `MainActivity`-re a `manifest.xml`-ben.
+Most már, hogy bekonfiguráltuk a *splash* képernyőnket, már csak be kell állítanunk a használatát. Ehhez először az imént létrehozott stílust kell alkalmaznunk `MainActivity`-re a `AndroidManifest.xml`-ben.
 
 
 ```xml
@@ -263,7 +263,7 @@ class MainActivity : ComponentActivity() {
 ```
 
 !!!note "Splash Screen-NavGraph"
-    A Splash Screent a NavGraph segítségével is meg lehet oldani, erről a labor végén egy ismertető [feladat](#ismerteto-feladat-navgrap-splash) fog segítséget mutatni. (Ez nem szükséges a labor megszerzéséhez, a feladat nélkül is el lehet érni a maximális pontot, azonban az érdekesség kedvéért érdemes végig csinálni.)
+    A Splash Screent a NavGraph segítségével is meg lehet oldani, erről a labor végén egy ismertető [feladat](#extra-feladat-navgraph-splash) fog segítséget mutatni. (Ez nem szükséges a labor megszerzéséhez, a feladat nélkül is el lehet érni a maximális pontot, azonban az érdekesség kedvéért érdemes végig csinálni.)
 
 
 Próbáljuk ki az alkalmazásunkat!
@@ -686,9 +686,9 @@ fun PreviewListScreen() {
 	            .fillMaxSize()
 	    ) {
 	        val type = mapOf(
-	            "Bike" to R.mipmap.bikes,
-	            "Bus" to R.mipmap.bus,
-	            "Train" to R.mipmap.trains
+	            "Bike" to R.drawable.bikes,
+	            "Bus" to R.drawable.bus,
+	            "Train" to R.drawable.trains
 	        )
 	
 	        for (i in type) {
@@ -1095,7 +1095,7 @@ fun PreviewPassScreen() {
 }
 ```
 
-Mivel a `TicketScreen`-nek szüksége van a jegy típúsára, valamint az érvényességi idejére, ezt egy paraméterként kapja meg, majd ezt egy függvényen belül feldolgozzuk, és az alábbiak szerint használjuk fel.
+Mivel a `PassScreen`-nek szüksége van a jegy típusára, valamint az érvényességi idejére, ezt egy paraméterként kapja meg, majd ezt egy függvényen belül feldolgozzuk, és az alábbiak szerint használjuk fel.
 
 - `yyyy. mm. dd.;yyyy. mm. dd.;category` a felépítése a kapott Stringnek
 - Ezt feldaraboljuk a `;` mentén, majd a dátumot string interpoláció segítségével átadjuk a `Text` Composable értékének, a price-t pedig egy másik `Text` Composable-nak
@@ -1295,9 +1295,9 @@ installSplashScreen().apply {
 
 Illesszük ezt be a `MainActivity` `onCreate()` függvényébe a megfelelő helyre, majd próbáljuk ki az alkalmazást!
 
-### Extra feladat - NavGrap-Splash
+### Extra feladat - NavGraph-Splash
 
-Korábban ezt a képernyőt a [Splash Screen API](https://developer.android.com/develop/ui/views/launch/splash-screen) segítségével oldottuk meg, azonban többfajta lehetőség is van, ezek közül most a NavGrap segítségével fogunk egyet megnézni.
+Korábban ezt a képernyőt a [Splash Screen API](https://developer.android.com/develop/ui/views/launch/splash-screen) segítségével oldottuk meg, azonban többfajta lehetőség is van, ezek közül most a NavGraph segítségével fogunk egyet megnézni.
 
 Ez a képernyő lényegében egy ugyanolyan képernyő mint a többi. Itt első sorban hozzunk létre egy új *Kotlin Filet* a `screen` packagen belül, majd nevezzük el `SplashScreen`-nek, és írjuk bele az alábbi kódot:
 


### PR DESCRIPTION
Javítottam az alábbi hibákat a 2. Mobil laborban:
1. A 'Splash képernyő' bekezdésben `manifest.xml` van írva, ilyen fájl nem létezik, javítottam `AndroidManifest.xml`-re
 
2. Az `Extra feladat NavGrap-Splash` bekezdéscím el van írva, javítottam `Extra feladat NavGraph-Splash`, valamint a hozzá tartozó linket `#ismerteto-feladat-navgrap-splash`, is javítottam, hogy erre a bekezdésre mutasson, `#extra-feladat-navgraph-splash`-re.

3. Az 'Login képernyő' bekezdésbeli `#ismerteto-feladat-screen-file` linket javítottam `#extra-feladat-kulonallo-screen-file`-ra. 

4. A #67-ben megjelölt elírásokat javítottam 

5. A 'kompakt megoldás' bekezdés kódrészletében az `R.mipmap`-ek helyére `R.drawable`-eket írtam, mert ez a helyes hivatkozás a megadott képekre.



Pallos Gábor (QN1SXN)     