### PR TITLE
Lab4 HorizontalPager Scroll Fix

### DIFF
--- a/docs/laborok/04-android-ui-charts/index.md
+++ b/docs/laborok/04-android-ui-charts/index.md
@@ -681,7 +681,7 @@ fun ProfileScreen(
             state = pagerState
         ) {
 
-            when (pagerState.currentPage) {
+            when (it) {
                 0 -> {
                     ProfileFirstPage(
                         name = profile.name,
@@ -710,7 +710,7 @@ fun PreviewProfileScreen() {
 }
 ```
 
-Itt először is létre kell hozunk egy `pagerState` nevű változót, amit át fogunk adni a `HorizontalPager`-nek. Ez tartalmazza, hogy hány oldal lesz az adott *Composable*-ön. Ezt követően szükség lesz egy profilra, amit már korábban definiáltunk egy `object`-ként. Végül a `HorizontalPager` segítségével létrehozzuk a lapozható oldalt, amin elhelyezzük a két *Composable* függvényt 1-1 oldalként.
+Itt először is létre kell hozunk egy `pagerState` nevű változót, amit át fogunk adni a `HorizontalPager`-nek. Ez tartalmazza, hogy hány oldal lesz az adott *Composable*-ön. Ezt követően szükség lesz egy profilra, amit már korábban definiáltunk egy `object`-ként. Végül a `HorizontalPager` segítségével létrehozzuk a lapozható oldalt, amin elhelyezzük a két *Composable* függvényt 1-1 oldalként. Az aktuális oldalt pedig az `it` segítségével választjuk ki.
 
 Végük kössük be a `ProfileScreen`-t a navigáciba:
 


### PR DESCRIPTION
Sziasztok!

Arra lettem figyelmes hogy a **4. Android labor Profil képernyő készítése** feladatban az elkészített feladatban a `HorizontalPager` használata során, amikor a két oldalt váltogatjuk, egészen addig amíg a képernyő feléhez nem érünk, addig a következő oldal tartalma helyett az eredeti oldal adatait mutatja a képernyő. A problémát a legjobban a következő Issue írja le: [https://github.com/google/accompanist/issues/1296](https://github.com/google/accompanist/issues/1296)

Ezzel kapcsolatban találtam több helyen is megoldást, mint ahogy a fentebbi Issue-ban is le lett írva. A fő probléma az volt, hogy a `CurrentPage` alapján lett állítva a tartalom az összes ablakon, nem pedig a saját tartalma szerint, ami szerintem így egy hiba volt, de amennyiben nem a `CurrentPage`, hanem az `it` alapján jelenítjük meg a tartalmakat, úgy ezt a problémát ki lehet küszöbölni.

Remélem hogy ennek a problémának ez egy jó megoldása.

Abóczki Richárd
Neptun: KN82OW