### PR TITLE
fix lab06: change f4.png content requirements

### DIFF
--- a/docs/laborok/06-android-room/index.md
+++ b/docs/laborok/06-android-room/index.md
@@ -1396,7 +1396,7 @@ Az alkalmazásunk most már képes tételek felvételére, és azok elmentésér
 Az iménti feladatrészben nem csak a perzisztens tárolást valósítottuk meg, hanem architekturálisan is jól átgondolt alkalmazást készítettünk. Ezt támasztja alá az is, hogy ahhoz, hogy az adataink ne csak a memóriában tárolódjanak, hanem adatbázisba kerüljenek, csak a *Room* adatbázishoz tartozó implementációs részeket kellett megírnunk, és a megfelelő *repository*-t inicializálni. Nem kellett változtatnunk sem a *viewModel*-en, sem a *screen*-en.
 
 !!!example "BEADANDÓ (1 pont)"
-	Készíts egy **képernyőképet**, amelyen látszik a **bevásárlólista több tétellel** (emulátoron, készüléket tükrözve vagy képernyőfelvétellel), a **`ShoppingListViewModel` kódja**, valamint a **neptun kódod egy termék neveként**! A képet a megoldásban a repository-ba **f4.png** néven töltsd föl! 
+	Készíts egy **képernyőképet**, amelyen látszik a **bevásárlólista több tétellel** (emulátoron, készüléket tükrözve vagy képernyőfelvétellel), a **`RoomShoppingListRepository` kódja**, valamint a **neptun kódod egy termék neveként**! A képet a megoldásban a repository-ba **f4.png** néven töltsd föl! 
 
 	A képernyőkép szükséges feltétele a pontszám megszerzésének.
 


### PR DESCRIPTION
Labor javítások közben, azt vettem észre, hogy ha ugyancsak a `ShoppingListViewModel `-t fotózzák be az f4.png beadásnál is, mint ahogy azt az f3.png-nél kellett, akkor a javításnál ennek semmi hozzáadott értéke nincs, mert ez az osztály egyáltalán nem változott közben. Ezért javasolom, egy olyan forráskód screenshot-olását amit az adott feladatban kellett létrehozni és a perzisztens adattárolás megvalósításához szükséges.