### PR TITLE
4.2_navbar_clarification

### DIFF
--- a/docs/laborok/09-css/index.md
+++ b/docs/laborok/09-css/index.md
@@ -362,7 +362,7 @@ A fejlécnek így kell kinéznie
 A logó mellett két elemből álló **menüsor** található, ahol az elemek átnavigálnak rendre az `index.html` és `contact.html` oldalakra az aktuális oldalról, megnevezésük: *Főoldal*, *Kapcsolat* (ezeket az oldalakat nem kell elkészíteni)!
 
 * A menüsort `<ul>` és `<li>` elemek használatával strukturáld. (Tipp: `display: inline-block`)
-* A menüpontok betűmérete 1.1em legyen, előtérszíne fehér. Az egeret a menüpontra helyezve (Tipp: `:hover` pszeudoclass) a háttérszín legyen szürke.
+* A menüpontok betűmérete 1.1em legyen, előtérszíne fehér. Az egeret a menüpontra helyezve (Tipp: `:hover` pszeudoclass) a betű színe legyen szürke.
 * A menüpontok szövege legyen függőlegesen középre igazítva. (Tipp: `line-height`)
 * Ügyeljen rá, hogy görgetéskor a tartalom ne takarja ki a menüsort! (Tipp: `z-index`)
 


### PR DESCRIPTION
A 9. labor 4.2 leírásában ellentmondás volt.

- A menüpontok betűmérete 1.1em legyen, előtérszíne fehér. Az egeret a menüpontra helyezve (Tipp: :hover pszeudoclass) a **háttérszín** legyen szürke.
- Ha egy menupont (link) fölé visszük az egeret, akkor a **betű színe** legyen szürke.

Ha a háttér és a betű szín is szürke nem látszik a szöveg.